### PR TITLE
Added toggle for Google URL Shortener

### DIFF
--- a/booru.js
+++ b/booru.js
@@ -88,7 +88,12 @@ function getDanbooru(message, cmds) {
         return console.error('Bad File Get at Index ' +
          selected_idx + ' on data:\n' + JSON.stringify(body));
       }
-      sendGoogleShortenerRequest(message, decodeURIComponent(tagStr) + '\n', imgUrl);
+
+      if (config.use_shortener === true) {
+        sendGoogleShortenerRequest(message, decodeURIComponent(tagStr) + '\n', imgUrl);
+      } else {
+        message.channel.sendMessage(decodeURIComponent(tagStr) + '\n' + imgUrl);
+      }
   }).catch(function (err) {
     return console.error('Request Failed: ' + err);
     message.channel.sendMessage('Request Failed. Try again.');

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ FUBUKI.on('message', message => {
       let newCmd = cmds;
       newCmd.push('rating:safe');
       booru.getDanbooru(message, newCmd);
+      message.delete()
       break;
     case '!remindme':
       remind.remindMe(message);


### PR DESCRIPTION
Discord has changed so urls from url shorteners no longer give link
previews. A toggle was added on the off chance Discord changes this
policy.